### PR TITLE
Update node.js

### DIFF
--- a/lib/configs/node.js
+++ b/lib/configs/node.js
@@ -13,6 +13,7 @@ module.exports = {
     // Place to specify ESLint rules. Can be used to overwrite rules specified from the extended configs
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+    '@typescript-eslint/explicit-function-return-type': ['warn', { allowExpressions: true }],
     'padding-line-between-statements': [
       'error',
       { blankLine: 'always', prev: '*', next: 'return' },


### PR DESCRIPTION
This lets us write things like relation decorators in TypeORM without needing to type them:

```
 @ManyToOne(() => User, user => user.availabilitySchedules)
```

Prior to this change, both arguments to `ManyToOne` would be lint warnings.