### PR TITLE
chore(dependencies): add dependabot config

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,6 @@
+version: 1
+update_configs:
+  - package_manager: 'javascript'
+    directory: '/'
+    update_schedule: 'live'
+    version_requirement_updates: 'increase_versions_if_necessary'


### PR DESCRIPTION
This is necessary to automatically keep `package.json` in sync with lockfile changes. 🎩 to @alvincrespo for noticing this and manually updating in #16 