### PR TITLE
fix: change to weekly update schedule

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -2,5 +2,5 @@ version: 1
 update_configs:
   - package_manager: 'javascript'
     directory: '/'
-    update_schedule: 'live'
+    update_schedule: 'weekly'
     version_requirement_updates: 'increase_versions_if_necessary'


### PR DESCRIPTION
This changes the dependabot settings to update on a weekly basis instead of live. 