### PR TITLE
fix(dependabot, dependencies): change to monthly updates and add dependency

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -2,7 +2,7 @@ version: 1
 update_configs:
   - package_manager: 'javascript'
     directory: '/'
-    update_schedule: 'weekly'
+    update_schedule: 'monthly'
     version_requirement_updates: 'auto' # Increase versions if an app, widen ranges if a library
     automerged_updates:
       - match:

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "babel-eslint": "^10.0.1",
     "eslint-config-prettier": "^6.5.0",
     "eslint-config-react-app": "^5.0.2",
-    "eslint-plugin-import": "^2.17.3",
+    "eslint-plugin-import": "^2.19.1",
     "eslint-plugin-jsx-a11y": "^6.2.1",
     "eslint-plugin-prettier": "^3.1.1",
     "eslint-plugin-react": "^7.13.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1864,7 +1864,7 @@ eslint-plugin-flowtype@2.50.3:
   dependencies:
     lodash "^4.17.10"
 
-eslint-plugin-import@^2.17.3:
+eslint-plugin-import@^2.19.1:
   version "2.19.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.19.1.tgz#5654e10b7839d064dd0d46cd1b88ec2133a11448"
   integrity sha512-x68131aKoCZlCae7rDXKSAQmbT5DQuManyXo2sK6fJJ0aK5CWAkv6A6HJZGgqC8IhjQxYPgo6/IY4Oz8AFsbBw==


### PR DESCRIPTION
This PR adds a missing dependency (eslint-plugin-import) and updates the `dependabot` config to only open PRs on a monthly basis. I think this is more practical for a project like this. 

Fixes #61 
Fixes #79 