### PR TITLE
fix: allow unused variables that are prefixed with an underscore

### DIFF
--- a/lib/configs/node.js
+++ b/lib/configs/node.js
@@ -11,7 +11,7 @@ module.exports = {
   rules: {
     // Place to specify ESLint rules. Can be used to overwrite rules specified from the extended configs
     '@typescript-eslint/no-explicit-any': 'off',
-    '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+    '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }],
     '@typescript-eslint/explicit-function-return-type': ['warn', { allowExpressions: true }],
     'padding-line-between-statements': [
       'error',

--- a/lib/configs/react.js
+++ b/lib/configs/react.js
@@ -21,7 +21,7 @@ module.exports = {
     'react-hooks/rules-of-hooks': 'error',
     'react-hooks/exhaustive-deps': 'warn',
     '@typescript-eslint/explicit-function-return-type': 'off',
-    '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+    '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }],
     'jsx-a11y/no-onchange': 'off',
     'import/order': [
       'warn',


### PR DESCRIPTION
This prevents a lint error for unused variables that are prefixed with an underscore.