### PR TITLE
feat: Remove excludes from plugin

### DIFF
--- a/lib/configs/react.js
+++ b/lib/configs/react.js
@@ -1,6 +1,5 @@
 module.exports = {
   parser: '@typescript-eslint/parser', // Specifies the ESLint parser
-  ignorePatterns: ['generated', 'node_modules/', 'types', 'cypress', 'scripts'],
   extends: [
     'react-app', // from create react app
     'plugin:jsx-a11y/recommended',


### PR DESCRIPTION
In a project using this plugin, we want lint to work on the `cypress` directory.

Rather than defining these excludes within the plugin, since a lot of consumers of this might not use the same file structure as we do, we should remove them from here and advocate for using a `.eslintignore` file in your project or adding your excludes at a project level. 